### PR TITLE
Fix Railway deployment: Replace psycopg2 with psycopg2-binary and add…

### DIFF
--- a/chatbot-system/backend/Dockerfile
+++ b/chatbot-system/backend/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
+    libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install Python dependencies

--- a/chatbot-system/backend/requirements.txt
+++ b/chatbot-system/backend/requirements.txt
@@ -53,7 +53,7 @@ pathspec==0.12.1
 platformdirs==4.4.0
 pluggy==1.6.0
 propcache==0.3.2
-psycopg2==2.9.10
+psycopg2-binary==2.9.10
 pyasn1==0.6.1
 pycparser==2.23
 pydantic==2.11.9


### PR DESCRIPTION
… libpq-dev

- Replace psycopg2 with psycopg2-binary for easier installation
- Add libpq-dev to Dockerfile system dependencies
- Fixes PostgreSQL driver build errors in Railway deployment